### PR TITLE
msgpack-python 1.0.7 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,18 +10,21 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  ignore_run_exports_from:
+    - {{ compiler('cxx') }}
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython                                 # [build_platform != target_platform]
+    - python
+    - cython
     - {{ compiler("cxx") }}
   host:
     - python
     - pip
-    - cython >=0.16
+    - cython >=3.0.11,<3.1.0
+    - setuptools
+    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - cython >=3.0.11,<3.1.0
     - setuptools
     - wheel
-    - tapi  # [osx-64]
+    - tapi  # [osx and x86_64]
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   sha256: 572efc93db7a4d27e404501975ca6d2d9775705c2d922390d878fcf768d92c87
 
 build:
+  skip: True  # [py<38 or py>312]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   ignore_run_exports_from:
@@ -17,7 +18,7 @@ build:
 requirements:
   build:
     - python
-    - cython
+    - {{ compiler("c") }}
     - {{ compiler("cxx") }}
   host:
     - python
@@ -31,14 +32,25 @@ requirements:
 test:
   imports:
     - msgpack
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: http://msgpack.org/
+  home: https://msgpack.org/
   license: Apache-2.0
   license_file: COPYING
   summary: MessagePack (de)serializer
   license_family: Apache
   dev_url: https://github.com/msgpack/msgpack-python
+  doc_url: https://github.com/msgpack/msgpack/blob/master/spec.md
+  description: |
+    MessagePack is an efficient binary serialization format. 
+    It lets you exchange data among multiple languages like JSON.
+    But it's faster and smaller. Small integers are encoded into a 
+    single byte, and typical short strings require only one extra
+    byte in addition to the strings themselves.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - cython >=3.0.11,<3.1.0
     - setuptools
     - wheel
+    - tapi  # [osx-64]
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - cython >=3.0.11,<3.1.0
     - setuptools
     - wheel
-    - tapi  # [osx and x86_64]
   run:
     - python
 


### PR DESCRIPTION
msgpack-python 1.0.7 

**Destination channel:** Defaults

### Links

- [PKG-8322]
- dev_url:        https://github.com/msgpack/msgpack
- conda_forge:    None
- pypi:           https://pypi.org/project/msgpack/1.0.7
- pypi inspector: https://inspector.pypi.io/project/msgpack/1.0.7

### Explanation of changes:

- new version number


[PKG-8322]: https://anaconda.atlassian.net/browse/PKG-8322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ