### PR TITLE
msgpack-python 1.1.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,16 @@
-{% set version = "1.0.7" %}
+{% set name = "msgpack-python" %}
+{% set version = "1.1.1" %}
 
 package:
-  name: msgpack-python
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/m/msgpack/msgpack-{{ version }}.tar.gz
-  sha256: 572efc93db7a4d27e404501975ca6d2d9775705c2d922390d878fcf768d92c87
+  url: https://pypi.io/packages/source/{{ name[0] }}/msgpack/msgpack-{{ version }}.tar.gz
+  sha256: 77b79ce34a2bdab2594f490c8e80dd62a02d650b91a75159a63ec413b8d104cd
 
 build:
-  skip: True  # [py<38 or py>312]
+  skip: True  # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   ignore_run_exports_from:
@@ -23,37 +24,45 @@ requirements:
   host:
     - python
     - pip
-    - cython >=3.0.11,<3.1.0
-    - setuptools
-    - wheel
+    - cython
+    - setuptools >=75.3.0
   run:
     - python
 
 test:
+  source_files:
+    - test
   imports:
     - msgpack
+    - msgpack.exceptions
+    - msgpack.ext
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('msgpack')=='{{ version }}')"
+    - pytest -v test
 
 about:
-  home: https://msgpack.org/
+  home: https://msgpack.org
+  summary: MessagePack (de)serializer
   license: Apache-2.0
   license_file: COPYING
-  summary: MessagePack (de)serializer
   license_family: Apache
-  dev_url: https://github.com/msgpack/msgpack-python
-  doc_url: https://github.com/msgpack/msgpack/blob/master/spec.md
   description: |
-    MessagePack is an efficient binary serialization format. 
+    MessagePack is an efficient binary serialization format.
     It lets you exchange data among multiple languages like JSON.
-    But it's faster and smaller. Small integers are encoded into a 
+    But it's faster and smaller. Small integers are encoded into a
     single byte, and typical short strings require only one extra
     byte in addition to the strings themselves.
+  dev_url: https://github.com/msgpack/msgpack-python
+  doc_url: https://github.com/msgpack/msgpack/blob/master/spec.md
 
 extra:
   recipe-maintainers:
     - jakirkham
     - ocefpaf
     - carlodri
+  skip-lints:
+  - missing_wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,8 @@ build:
   skip: True  # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  ignore_run_exports_from:
-    - {{ compiler('cxx') }}
+  ignore_run_exports:
+    - libcxx
 
 requirements:
   build:
@@ -26,6 +26,7 @@ requirements:
     - pip
     - cython
     - setuptools >=75.3.0
+    - wheel
   run:
     - python
 
@@ -64,5 +65,3 @@ extra:
     - jakirkham
     - ocefpaf
     - carlodri
-  skip-lints:
-  - missing_wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,6 @@ build:
   skip: True  # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  ignore_run_exports:
-    - libcxx
 
 requirements:
   build:


### PR DESCRIPTION
msgpack-python 1.1.1 

**Destination channel:** Defaults

### Links

- [PKG-8564]
- dev_url:        https://github.com/msgpack/msgpack-python/tree/v1.1.1
- conda_forge:    https://github.com/conda-forge/msgpack-python-feedstock
- pypi:           https://pypi.org/project/msgpack/1.1.1
- pypi inspector: https://inspector.pypi.io/project/msgpack/1.1.1

### Explanation of changes:

- new version number


[PKG-8564]: https://anaconda.atlassian.net/browse/PKG-8564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ