### PR TITLE
msgpack-python 1.2.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,29 @@
 {% set name = "msgpack-python" %}
-{% set version = "1.1.1" %}
+{% set version = "1.2.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/msgpack/msgpack-{{ version }}.tar.gz
-  sha256: 77b79ce34a2bdab2594f490c8e80dd62a02d650b91a75159a63ec413b8d104cd
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name.split('-')[0] }}/{{ name.split('-')[0] }}-{{ version }}.tar.gz
+  sha256: 8e17af38197bf58e7e819041678f6178f4491493f5b8c8580414f40f7c2c3c41
 
 build:
-  skip: True  # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<310]
 
 requirements:
   build:
-    - python
+    - {{ stdlib("c") }}
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
   host:
-    - python
     - pip
+    - python
     - cython
-    - setuptools >=75.3.0
-    - wheel
+    - setuptools 78.1.1
   run:
     - python
 
@@ -35,13 +34,13 @@ test:
     - msgpack
     - msgpack.exceptions
     - msgpack.ext
-  requires:
-    - pip
-    - pytest
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('msgpack')=='{{ version }}')"
     - pytest -v test
+  requires:
+    - pip
+    - pytest >=9.0.3
 
 about:
   home: https://msgpack.org


### PR DESCRIPTION
msgpack-python 1.2.0 

**Destination channel:** Defaults

### Links

- [PKG-15312]
- dev_url:        https://github.com/msgpack/msgpack-python/tree/v1.2.0
- conda_forge:    https://github.com/conda-forge/msgpack-python-feedstock
- pypi:           None
- pypi inspector: None

### Explanation of changes:

- new version number


[PKG-15312]: https://anaconda.atlassian.net/browse/PKG-15312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ