### PR TITLE
msgpack-python 1.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "msgpack-python" %}
-{% set version = "1.2.0" %}
+{% set version = "1.2.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name.split('-')[0] }}/{{ name.split('-')[0] }}-{{ version }}.tar.gz
-  sha256: 8e17af38197bf58e7e819041678f6178f4491493f5b8c8580414f40f7c2c3c41
+  sha256: 04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647
 
 build:
   number: 0
@@ -22,7 +22,7 @@ requirements:
   host:
     - pip
     - python
-    - cython
+    - cython >=3.2.5
     - setuptools 78.1.1
   run:
     - python


### PR DESCRIPTION
## msgpack-python 1.2.1

**Destination channel:** defaults

### Links
- [PKG-15971](https://anaconda.atlassian.net/browse/PKG-15971)
- [PyPI](https://pypi.org/project/msgpack/1.2.1/)
- [GitHub release](https://github.com/msgpack/msgpack-python/releases/tag/v1.2.1)

### Explanation of changes:
- Updated msgpack-python from 1.2.0 to 1.2.1
- Pins `cython >=3.2.5` in host to match upstream build requirements (1.2.1 bumps Cython from 3.1.x)
- Upstream 1.2.1 fixes a segfault when calling `Unpacker.unpack()` or `Unpacker.skip()` after an unpacking failure ([GHSA-6v7p-g79w-8964](https://github.com/advisories/GHSA-6v7p-g79w-8964))




[PKG-15971]: https://anaconda.atlassian.net/browse/PKG-15971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ